### PR TITLE
shinesolutions/aem-helloworld-author-dispatcher #5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Changed
-- Changed Apache keep alive configurations
+- Optimise Apache keep alive configurations (KeepAlive On, MaxKeepAliveRequests 0, KeepAliveTimeout 65)
 
 ## 0.11.0 - 2020-01-23
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Changed Apache keep alive configurations
 
 ## 0.11.0 - 2020-01-23
 ### Changed

--- a/apache-conf-templates/httpd.conf.epp
+++ b/apache-conf-templates/httpd.conf.epp
@@ -7,9 +7,9 @@ ServerName "<%= $facts[fqdn] %>"
 ServerRoot "/etc/httpd"
 PidFile run/httpd.pid
 Timeout 120
-KeepAlive Off
-MaxKeepAliveRequests 100
-KeepAliveTimeout 15
+KeepAlive On
+MaxKeepAliveRequests 0
+KeepAliveTimeout 65
 LimitRequestFieldSize 8190
 
 


### PR DESCRIPTION
* CPU usage in the dispatchers was too high and instances keep terminating before scale-up
Fix: Turn on keep-alives to reduce CPU utilization and improve response time. With keep-alives on, the load balancer doesn't need to establish a new TCP connection for every HTTP request.
KeepAlive is not set to On to fix the CPU usage problem.

* ALB terminates the connections after 60 seconds. so apache configuration should be higher than it.
Fix: When the keep-alive option is enabled, choose a longer keep-alive timeout than the load balancer idle timeout.
keep-alive time out is not set to 65. which is 5 seconds longer than default ALB timeout.

* Maximum number of keep-alive requests was low, so the queue will be full and and connection will time out with 5xx error
Fix: This option sets how many requests a single TCP connection serves when keep-alive is on. For optimal usage of resources, set the maximum number of keep-alive requests to 100 or higher.
This value is now set to 0 which means there wont be any limitation in number of keep-alive connections.